### PR TITLE
Implement `Clone` for `Emitter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,20 @@ pub fn hostname<'a>() -> String
     String::from_utf8_lossy(buf.as_slice()).into_owned()
 }
 
+impl<'e> Clone for Emitter<'e> {
+    fn clone(&self) -> Self {
+        Emitter {
+            defaults: self.defaults.clone(),
+            destination: self.destination.clone(),
+            app: self.app.clone(),
+            output: match self.output {
+                None => None,
+                Some(ref o) => Some(o.try_clone().expect("expected TcpStream to clone"))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
This allows us to try an reuse the `output` socket via an explicit
`Emitter#clone()` call.