### PR TITLE
feat: add a convenience `Emitter.emit_value`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,15 @@ impl<'e> Emitter<'e>
         self.emit(metric);
     }
 
+    pub fn emit_value<T>(&mut self, name: &str, value: T)
+        where T: serde::ser::Serialize
+    {
+        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
+        metric.insert("name", serde_json::to_value(name));
+        metric.insert("value", serde_json::to_value(value));
+        self.emit(metric);
+    }
+
     pub fn emit_name_val_tag(&mut self, name: &'e str, value: u32, tag: &'e str, tagv: &'e str)
     {
         let mut metric: BTreeMap<&str, Value> = BTreeMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,8 @@ fn main()
     custom.connect("tcp://localhost:4677");
 
     custom.emit_name("start");
-    custom.emit_f32("floating", 232.5);
+    custom.emit_value("floating", 232.5);
+    custom.emit_value("also-not-floating", "foo");
     custom.emit_i32("integer", 2048);
 
     let mut point: Point = Point::new();


### PR DESCRIPTION
Emit anything `serde_json` allows us to serialize.

@ceejbot I was wondering why we didn't do this - sounds like we could also alias all the other convenience methods to this?