### PR TITLE
breaking: Drastically simplify the API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numbat"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["C J Silverio <ceejceej@gmail.com>"]
 description = "An emitter for npm's numbat-metrics for Rust projects."
 homepage = "https://github.com/numbat-metrics/rust-emitter"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ An emitter for [numbat metrics](https://github.com/numbat-metrics/) for Rust pro
 
 [![crate](https://img.shields.io/crates/v/numbat.svg)](https://crates.io/crates/numbat)
 
-
 ## Usage
 
 Here's an example of using the emitter:
@@ -15,22 +14,19 @@ extern crate serde_json;
 
 use numbat::Point;
 
-let mut opts: Point = Point::new();
-opts.insert("tag", serde_json::to_value("local"));
-
-let mut emitter = numbat::Emitter::new(opts, "test-emitter");
+let mut emitter = numbat::Emitter::for_app("test-emitter");
 emitter.connect("tcp://localhost:4677");
 
-emitter.emit_name("start");
-emitter.emit_float("floating", 232.5);
-emitter.emit_int("integer", 2048);
-emitter.emit_unsigned("u16", 2048);
+emitter.emit_name("start"); // default value is 1
+emitter.emit("floating", 232.5);
+emitter.emit("integer", 2048);
+emitter.emit("u16", 2048);
 
 let mut point: Point = Point::new();
 point.insert("name", serde_json::to_value("inconvenience"));
 point.insert("tag", serde_json::to_value("subjective"));
 point.insert("value", serde_json::to_value(500.3));
-emitter.emit(point);
+emitter.emit_point(point);
 ```
 
 However, it might be a giant pain to pass an emitter object around. If you need only one, connected to only one numbat collector, you can use the singleton:
@@ -89,35 +85,22 @@ Emit a full numbat metric, with as many tags as you wish. The `time` and `value`
 
 Shortcut for emitting a metric with value 1.
 
-`emit_f32(&str, f32)`
-`emit_f64(&str, f64)`
+`emit_value(&str, T)`
 
-Shortcuts for emitting a metric with the given name and floating-point value.
+Shortcut for emitting a metric with the given name and a value of any type that [serde_json](https://github.com/serde-rs/json) can serialize.
 
-`emit_i32(&mut self, name: &'e str, value: i32)`  
-`emit_i64(&mut self, name: &'e str, value: i64)`  
-`emit_u32(&mut self, name: &'e str, value: u32)`  
-`emit_u16(&mut self, name: &'e str, value: u16)`
+`emit_name_val_tag(name: &'e str, value: T, tag: &'e str, tagv: T)`
 
-Shortcuts for emitting a metric with the given name and integer value, with various signedness & size.
-
-`emit_name_val_tag(name: &'e str, value: u32, tag: &'e str, tagv: &'e str)`
-
-Shortcut for another common pattern: a name/value pair with a tag/value pair (both strings). Here's an example of emitting a metric for an http response, with timing & status code:
-
-`emit_name_int_tag_uint(name: &'e str, value: u32, tag: &'e str, tagv: &'e str)`
+Shortcut for another common pattern: a name/value pair with a tag/value pair. Here's an example of emitting a metric for an http response, with timing & status code:
 
 `emit_name_val_tag("response", 23, "status", 200);`
 
-Emit a metric
 
 ## TODO
 
 There's no error handling to speak of yet. It won't crash on errors, but it doesn't try to reconnect if it loses a connection. (I'm slowly untangling if/when the Rust TCPStream implementation bubbles errors up.)
 
 I have no idea how to test it other than the little program in `main.rs`. There's no UDP emitter implementation (just use TCP like you should anyway).
-
-The API for creating a point with custom fields could be nicer; would be great to hide the choice of `serde_json` from consumers. The API above covers most of the metrics we typically emit from a service.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl<'e> Emitter<'e>
         self.output = create_connection(dest);
     }
 
-    // The default write_all implemenation doesn't do useful things.
+    // The default write_all implementation doesn't do useful things.
     fn write_all(conn: &mut TcpStream, mut buf: &[u8]) -> Result<usize, io::Error>
     {
         // let total = buf.len();
@@ -149,7 +149,7 @@ impl<'e> Emitter<'e>
         }
     }
 
-    pub fn emit(&mut self, point: BTreeMap<&'e str, Value>)
+    pub fn emit_point(&mut self, point: BTreeMap<&'e str, Value>)
     {
         let mut metric = self.defaults.clone();
         metric.append(&mut point.clone());
@@ -173,86 +173,30 @@ impl<'e> Emitter<'e>
         self.write(metric);
     }
 
-    pub fn emit_name(&mut self, name: &'e str)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        self.emit(metric);
-    }
-
-    pub fn emit_value<T>(&mut self, name: &str, value: T)
+    pub fn emit<T>(&mut self, name: &str, value: T)
         where T: serde::ser::Serialize
     {
         let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
         metric.insert("name", serde_json::to_value(name));
         metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
+        self.emit_point(metric);
     }
 
-    pub fn emit_name_val_tag(&mut self, name: &'e str, value: u32, tag: &'e str, tagv: &'e str)
+    pub fn emit_name(&mut self, name: &'e str)
+    {
+        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
+        metric.insert("name", serde_json::to_value(name));
+        self.emit_point(metric);
+    }
+
+    pub fn emit_name_val_tag<T>(&mut self, name: &'e str, value: T, tag: &'e str, tagv: T)
+        where T: serde::ser::Serialize
     {
         let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
         metric.insert("name", serde_json::to_value(name));
         metric.insert("value", serde_json::to_value(value));
         metric.insert(tag, serde_json::to_value(tagv));
-        self.emit(metric);
-    }
-
-    pub fn emit_name_int_tag_uint(&mut self, name: &'e str, value: i64, tag: &'e str, tagv: u16)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        metric.insert(tag, serde_json::to_value(tagv));
-        self.emit(metric);
-    }
-
-    pub fn emit_f32(&mut self, name: &'e str, value: f32)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
-    }
-
-    pub fn emit_f64(&mut self, name: &'e str, value: f64)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
-    }
-
-    pub fn emit_i32(&mut self, name: &'e str, value: i32)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
-    }
-
-    pub fn emit_i64(&mut self, name: &'e str, value: i64)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
-    }
-
-    pub fn emit_u32(&mut self, name: &'e str, value: u32)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
-    }
-
-    pub fn emit_u16(&mut self, name: &'e str, value: u16)
-    {
-        let mut metric: BTreeMap<&str, Value> = BTreeMap::new();
-        metric.insert("name", serde_json::to_value(name));
-        metric.insert("value", serde_json::to_value(value));
-        self.emit(metric);
+        self.emit_point(metric);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,15 +13,15 @@ fn main()
     custom.connect("tcp://localhost:4677");
 
     custom.emit_name("start");
-    custom.emit_value("floating", 232.5);
-    custom.emit_value("also-not-floating", "foo");
-    custom.emit_i32("integer", 2048);
+    custom.emit("floating", 232.5);
+    custom.emit("also-not-floating", "foo");
+    custom.emit("integer", 2048);
 
     let mut point: Point = Point::new();
     point.insert("name", serde_json::to_value("inconvenience"));
     point.insert("tag", serde_json::to_value("subjective"));
     point.insert("value", serde_json::to_value(500.3));
-    custom.emit(point);
+    custom.emit_point(point);
 
     // Create a local emitter with default fields & use it.
     let mut opts: Point = Point::new();
@@ -29,7 +29,7 @@ fn main()
 
     let mut with_defaults = numbat::Emitter::new(opts, "numbat-emitter");
     with_defaults.connect("tcp://localhost:4677");
-    with_defaults.emit_u16("unsigned16", 256_u16);
+    with_defaults.emit("unsigned16", 256_u16);
 
     // Now initialize & use the global emitter.
     let mut opts2: Point = Point::new();
@@ -38,5 +38,5 @@ fn main()
     emitter().init(opts2, "numbat-emitter");
     emitter().connect("tcp://localhost:4677");
     emitter().emit_name("initialization");
-    emitter().emit_name_int_tag_uint("response", 23, "status", 200);
+    emitter().emit_name_val_tag("response", 23, "status", 200);
 }


### PR DESCRIPTION
`emit()` ➜ `emit_point()`
`emit_value()` ➜ `emit()`

All type-specific emit functions are gone, in favor of the generic function. The `emit_name_val_tag()` convenience remains, but it takes any `serde_json` serializable type now.

Updated sample usage in `main.rs`. Updated README. Bumped minor version number.