### PR TITLE
breaking: tcp -> nsq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numbat"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["C J Silverio <ceejceej@gmail.com>"]
 description = "An emitter for npm's numbat-metrics for Rust projects."
 homepage = "https://github.com/numbat-metrics/rust-emitter"
@@ -9,9 +9,10 @@ license = "ISC"
 readme = "README.md"
 
 [dependencies]
+hyper = "0.10"
 lazy_static = "0.1.0"
 libc = "0.2.17"
+regex = "0.2"
 serde = "0.8"
 serde_json = "0.8"
 time = "0.1"
-url = "1.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numbat"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["C J Silverio <ceejceej@gmail.com>"]
 description = "An emitter for npm's numbat-metrics for Rust projects."
 homepage = "https://github.com/numbat-metrics/rust-emitter"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ extern crate serde_json;
 use numbat::Point;
 
 let mut emitter = numbat::Emitter::for_app("test-emitter");
-emitter.connect("tcp://localhost:4677");
+emitter.connect("nsq://localhost:4151/pub?topic=metrics");
 
 emitter.emit_name("start"); // default value is 1
 emitter.emit("floating", 232.5);
@@ -29,7 +29,7 @@ point.insert("value", serde_json::to_value(500.3));
 emitter.emit_point(point);
 ```
 
-However, it might be a giant pain to pass an emitter object around. If you need only one, connected to only one numbat collector, you can use the singleton:
+However, it might be a giant pain to pass an emitter object around. If you need only one, posting to only one destination, you can use the singleton:
 
 ```rust
 extern crate numbat;
@@ -41,7 +41,7 @@ let mut defaults: Point = Point::new();
 defaults.insert("using_emitter", serde_json::to_value("global"));
 
 numbat::emitter().init(defaults, "global-emitter");
-numbat::emitter().connect("tcp://localhost:4677");
+numbat::emitter().connect("nsq://localhost:4151/pub?topic=global-metrics");
 numbat::emitter().emit_name("start");
 ```
 
@@ -75,7 +75,7 @@ Call this to set up the global emitter for use.
 
 `connect(uri: &str)`
 
-You must call this before your metrics go anywhere. Takes a URI of the form `tcp://hostname:portnum`. Everything is treated as TCP at the moment, so udp numbat collectors are useless with this library.
+You must call this before your metrics go anywhere. Accepts any valid URI; will post directly to that URI. The only processing done is to replace an initial `nsq` with `http`, so you may pass in `nsq://localhost:4151/` if you wish.
 
 `emit(mut Point)`
 
@@ -95,12 +95,9 @@ Shortcut for another common pattern: a name/value pair with a tag/value pair. He
 
 `emit_name_val_tag("response", 23, "status", 200);`
 
-
 ## TODO
 
-There's no error handling to speak of yet. It won't crash on errors, but it doesn't try to reconnect if it loses a connection. (I'm slowly untangling if/when the Rust TCPStream implementation bubbles errors up.)
-
-I have no idea how to test it other than the little program in `main.rs`. There's no UDP emitter implementation (just use TCP like you should anyway).
+Testing.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,13 +85,15 @@ impl<'e> Emitter<'e>
         }
     }
 
-    fn take_error(&mut self) -> Option<Error> {
+    fn take_error(&mut self) -> Option<Error>
+    {
         std::mem::replace(&mut self.last_error, None)
     }
 
     fn get_connection(&mut self) -> &Result<TcpStream, Error>
     {
-        if !self.output.is_ok() || self.take_error().is_some() {
+        if !self.output.is_ok() || self.take_error().is_some()
+        {
             self.output = create_connection(&self.destination);
         }
 
@@ -108,18 +110,16 @@ impl<'e> Emitter<'e>
     {
         self.get_connection();
 
-        match self.output {
-            Err(ref e) => {
-                self.last_error = Some(clone_error(e));
-            },
-            Ok(ref mut conn) => {
+        match self.output
+        {
+            Err(ref e) => { self.last_error = Some(clone_error(e)); },
+            Ok(ref mut conn) =>
+            {
                 let mline = serde_json::to_string(&metric).unwrap() + "\n";
                 match conn.write(mline.as_bytes())
                 {
                     Ok(_) => {},
-                    Err(ref e) => {
-                        self.last_error = Some(clone_error(e));
-                    }
+                    Err(ref e) => { self.last_error = Some(clone_error(e)); }
                 }
             }
         }
@@ -178,8 +178,6 @@ impl<'e> Emitter<'e>
 
 fn create_connection(dest: &str) -> Result<TcpStream, Error>
 {
-    // TODO udp vs tcp for full compatibility
-    // TODO reconnect on error
     let target = url::Url::parse(dest).ok().unwrap();
     TcpStream::connect((target.host_str().unwrap(), target.port().unwrap()))
 }
@@ -218,16 +216,17 @@ pub fn hostname<'a>() -> String
     String::from_utf8_lossy(buf.as_slice()).into_owned()
 }
 
-fn get_defaults(tmpl: Point) -> Point {
+fn get_defaults(tmpl: Point) -> Point
+{
     let mut defaults = tmpl.clone();
     defaults.insert("host", serde_json::to_value(hostname()));
     defaults
 }
 
-fn clone_error(e: &Error) -> Error {
+fn clone_error(e: &Error) -> Error
+{
     Error::new((*e).kind(), "cloned error")
 }
-
 
 impl<'e> Clone for Emitter<'e>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 #[macro_use]
 extern crate lazy_static;
+extern crate hyper;
 extern crate libc;
+extern crate regex;
 extern crate serde;
 extern crate serde_json;
 extern crate time;
-extern crate url;
 
+use hyper::Client;
 use libc::gethostname;
+use regex::Regex;
 use std::collections::BTreeMap;
-use std::io::prelude::*;
-use std::net::TcpStream;
 use std::sync::Mutex;
-use std::io::{Error,ErrorKind};
 
 lazy_static!
 {
@@ -28,9 +28,8 @@ pub type Point<'a> = BTreeMap<&'a str, serde_json::Value>;
 pub struct Emitter<'e>
 {
     defaults: Point<'e>,
-    output: Result<TcpStream, Error>,
-    last_error: Option<Error>,
-    destination: String,
+    client: Client,
+    target: String,
     app: String,
 }
 
@@ -41,16 +40,22 @@ impl<'e> Emitter<'e>
         Emitter
         {
             defaults: get_defaults(Point::new()),
-            output: Err(Error::new(ErrorKind::NotConnected, "not connected")),
+            client: Client::new(),
             app: String::from(""),
-            last_error: None,
-            destination: String::from("")
+            target: String::from("http://localhost:4151/pub?topic=metrics")
         }
     }
 
     pub fn for_app(app: &str) -> Emitter<'e>
     {
         Self::new(Point::new(), app)
+    }
+
+    pub fn connect(&mut self, target: &str)
+    {
+        let re = Regex::new(r"^nsq://").unwrap();
+        let result = re.replace(target, "http://");
+        self.target = result.into_owned();
     }
 
     pub fn init(&mut self, tmpl: Point<'e>, app: &str)
@@ -78,50 +83,19 @@ impl<'e> Emitter<'e>
         Emitter
         {
             defaults: get_defaults(tmpl),
-            output: Err(Error::new(ErrorKind::NotConnected, "not connected")),
+            client: Client::new(),
             app: t,
-            last_error: None,
-            destination: String::from("")
+            target: String::from("http://localhost:4151/pub?topic=metrics")
         }
-    }
-
-    fn take_error(&mut self) -> Option<Error>
-    {
-        std::mem::replace(&mut self.last_error, None)
-    }
-
-    fn get_connection(&mut self) -> &Result<TcpStream, Error>
-    {
-        if !self.output.is_ok() || self.take_error().is_some()
-        {
-            self.output = create_connection(&self.destination);
-        }
-
-        &self.output
-    }
-
-    pub fn connect(&mut self, dest: &str)
-    {
-        self.destination = String::from(dest);
-        self.get_connection();
     }
 
     fn write(&mut self, metric: Point)
     {
-        self.get_connection();
-
-        match self.output
+        let mline = serde_json::to_string(&metric).unwrap();
+        match self.client.post(&self.target).body(&mline).send()
         {
-            Err(ref e) => { self.last_error = Some(clone_error(e)); },
-            Ok(ref mut conn) =>
-            {
-                let mline = serde_json::to_string(&metric).unwrap() + "\n";
-                match conn.write(mline.as_bytes())
-                {
-                    Ok(_) => {},
-                    Err(ref e) => { self.last_error = Some(clone_error(e)); }
-                }
-            }
+            Ok(_) => { return; }, // we don't care!
+            Err(e) => { println!("{}", e); }, // bummer, man, but we still don't care
         }
     }
 
@@ -176,12 +150,6 @@ impl<'e> Emitter<'e>
     }
 }
 
-fn create_connection(dest: &str) -> Result<TcpStream, Error>
-{
-    let target = url::Url::parse(dest).ok().unwrap();
-    TcpStream::connect((target.host_str().unwrap(), target.port().unwrap()))
-}
-
 pub fn hostname<'a>() -> String
 {
     let bufsize = 255;
@@ -223,11 +191,6 @@ fn get_defaults(tmpl: Point) -> Point
     defaults
 }
 
-fn clone_error(e: &Error) -> Error
-{
-    Error::new((*e).kind(), "cloned error")
-}
-
 impl<'e> Clone for Emitter<'e>
 {
     fn clone(&self) -> Self
@@ -235,18 +198,9 @@ impl<'e> Clone for Emitter<'e>
         Emitter
         {
             defaults: self.defaults.clone(),
-            destination: self.destination.clone(),
+            target: self.target.clone(),
             app: self.app.clone(),
-            output: match self.output
-            {
-                Err(ref e) => Err(clone_error(e)),
-                Ok(ref o) => o.try_clone()
-            },
-            last_error: match self.last_error
-            {
-                Some(ref e) => Some(clone_error(e)),
-                None => None
-            }
+            client: Client::new(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main()
 
     // Create a local emitter & use it.
     let mut custom = numbat::Emitter::for_app("numbat-emitter");
-    custom.connect("tcp://localhost:4677");
+    custom.connect("http://localhost:4151/pub?topic=rust");
 
     custom.emit_name("start");
     custom.emit("floating", 232.5);
@@ -28,7 +28,7 @@ fn main()
     opts.insert("tag", serde_json::to_value("prefilled"));
 
     let mut with_defaults = numbat::Emitter::new(opts, "numbat-emitter");
-    with_defaults.connect("tcp://localhost:4677");
+    with_defaults.connect("nsq://localhost:4151/pub?topic=rust");
     with_defaults.emit("unsigned16", 256_u16);
 
     // Now initialize & use the global emitter.
@@ -36,7 +36,7 @@ fn main()
     opts2.insert("tag", serde_json::to_value("global"));
 
     emitter().init(opts2, "numbat-emitter");
-    emitter().connect("tcp://localhost:4677");
+    emitter().connect("nsq://localhost:4151/pub?topic=rust");
     emitter().emit_name("initialization");
     emitter().emit_name_val_tag("response", 23, "status", 200);
 }


### PR DESCRIPTION
Throw out a lot of code; replace it with the hyper client POSTing to a uri. This will need config work when we move to client certs, but it'll do for now to update our Rust services for the new metrics collection regime.

Docs & examples are updated as well.